### PR TITLE
Add bootstrap pin configuration

### DIFF
--- a/config.h
+++ b/config.h
@@ -20,6 +20,11 @@
 #define _AUTO              -1   /* set automatically */
 #define _DISABLE            0   /* disable feature */
 #define _ENABLE             1   /* enable feature */
+#define _HIGH               0   /* high pin level */
+#define _LOW                1   /* low pin level */
+#define _NONE               0   /* No Pull up/down */
+#define _DOWN               1   /* Pull up */
+#define _UP                 2   /* Pull down */
 /** DFU cipher definitions. */
 #define DFU_CIPHER_ARC4     10  /* ARCFOUR (Rivest RC-4) stream cipher */
 #define DFU_CIPHER_CHACHA   11  /* RFC7539-CHACHA20 stream cipher */
@@ -75,6 +80,8 @@
 /* DFU bootstrap port/pin settings. Set GPIOx or _DISABLE */
 #define DFU_BOOTSTRAP_GPIO  GPIOA
 #define DFU_BOOTSTRAP_PIN   1
+#define DFU_BOOTSTRAP_PULL  _UP
+#define DFU_BOOTSTRAP_LEVEL _LOW
 /* Double reset waiting time in mS. _DISABLE or time in mS */
 #define DFU_DBLRESET_MS     300
 /* User application address. _AUTO or page aligned address.

--- a/mcu/stm32f103.S
+++ b/mcu/stm32f103.S
@@ -1,4 +1,4 @@
-#include "../config.h"
+#include "config.h"
 #define FLASH_R_BASE    0x40022000
 #define FLASH_ACR       0x00
 #define FLASH_KEYR      0x04
@@ -33,6 +33,7 @@
 #define GPIO_CRH        0x04
 #define GPIO_IDR        0x08
 #define GPIO_BSRR       0x10
+#define GPIO_BRR        0x14
 
 #define SCB             0xE000ED00
 #define SCB_VTOR        0x08
@@ -153,14 +154,23 @@ Reset_Handler:
 /* checking bootstrap pin */
     ldr     r1, =#DFU_BOOTSTRAP_GPIO
     ldr     r3, =#(0x0F << ((DFU_BOOTSTRAP_PIN & 0x07) << 2))
+
+#if !defined(DFU_BOOTSTRAP_PULL) || ( (defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL != _NONE)) )
     ldr     r2, =#(0x08 << ((DFU_BOOTSTRAP_PIN & 0x07) << 2))
+#else
+    ldr     r2, =#(0x04 << ((DFU_BOOTSTRAP_PIN & 0x07) << 2))
+#endif
     ldr     r4, [r1, #BOOTSTRAP_CRx]
     bics    r4, r3
     orrs    r4, r2
     str     r4, [r1, #BOOTSTRAP_CRx]
     movs    r2, #0x01
     lsls    r2, #(DFU_BOOTSTRAP_PIN)
+#if !defined(DFU_BOOTSTRAP_PULL) || ( (defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL == _UP)) )
     str     r2, [r1, #GPIO_BSRR]
+#else
+    str     r2, [r1, #GPIO_BRR]
+#endif
     movs    r4, #0x08
 .L_scan_bootstrap:
     ldr     r2, [r1, #GPIO_IDR]

--- a/mcu/stm32f103.S
+++ b/mcu/stm32f103.S
@@ -196,7 +196,12 @@ Reset_Handler:
     movs    r2, #0x00
     strb    r2, [r0, #RCC_APB2RSTR]
     strb    r2, [r0, #RCC_APB2ENR]
+#if ( (!defined(DFU_BOOTSTRAP_LEVEL)) || ( defined(DFU_BOOTSTRAP_LEVEL) && (DFU_BOOTSTRAP_LEVEL==_LOW)) )
     cbz     r4, .L_start_boot
+#else
+    cbnz    r4, .L_start_boot
+#endif
+
 /* jump to user section */
     ldr     r0, =#_APP_START
     ldr     r1, =#SCB

--- a/mcu/stm32f105.S
+++ b/mcu/stm32f105.S
@@ -182,7 +182,12 @@ Reset_Handler:
     movs    r2, #0x00
     strb    r2, [r0, #RCC_APB2RSTR]
     strb    r2, [r0, #RCC_APB2ENR]
+#if ( (!defined(DFU_BOOTSTRAP_LEVEL)) || ( defined(DFU_BOOTSTRAP_LEVEL) && (DFU_BOOTSTRAP_LEVEL==_LOW)) )
     cbz     r4, .L_start_boot
+#else
+    cbnz    r4, .L_start_boot
+#endif
+
 .L_jump_to_app:
 /* jump to user section */
     ldr     r0, =#_APP_START

--- a/mcu/stm32f105.S
+++ b/mcu/stm32f105.S
@@ -1,4 +1,4 @@
-#include "../config.h"
+#include "config.h"
 #define FLASH_R_BASE    0x40022000
 #define FLASH_ACR       0x00
 #define FLASH_KEYR      0x04
@@ -34,6 +34,7 @@
 #define GPIO_CRH        0x04
 #define GPIO_IDR        0x08
 #define GPIO_BSRR       0x10
+#define GPIO_BRR        0x14
 
 #define SCB             0xE000ED00
 #define SCB_VTOR        0x08
@@ -143,14 +144,24 @@ Reset_Handler:
 /* checking bootstrap pin */
     ldr     r1, =#DFU_BOOTSTRAP_GPIO
     ldr     r3, =#(0x0F << ((DFU_BOOTSTRAP_PIN & 0x07) << 2))
+
+#if !defined(DFU_BOOTSTRAP_PULL) || ( (defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL != _NONE)) )
     ldr     r2, =#(0x08 << ((DFU_BOOTSTRAP_PIN & 0x07) << 2))
+#else
+    ldr     r2, =#(0x04 << ((DFU_BOOTSTRAP_PIN & 0x07) << 2))
+#endif
+
     ldr     r4, [r1, #BOOTSTRAP_CRx]
     bics    r4, r3
     orrs    r4, r2
     str     r4, [r1, #BOOTSTRAP_CRx]
     movs    r2, #0x01
     lsls    r2, #(DFU_BOOTSTRAP_PIN)
+#if !defined(DFU_BOOTSTRAP_PULL) || ( (defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL == _UP)) )
     str     r2, [r1, #GPIO_BSRR]
+#else
+    str     r2, [r1, #GPIO_BRR]
+#endif
     movs    r4, #0x08
 .L_scan_bootstrap:
     ldr     r2, [r1, #GPIO_IDR]

--- a/mcu/stm32f303.S
+++ b/mcu/stm32f303.S
@@ -1,4 +1,4 @@
-#include "../config.h"
+#include "config.h"
 #define FLASH_R_BASE    0x40022000
 #define FLASH_ACR       0x00
 #define FLASH_KEYR      0x04
@@ -155,7 +155,7 @@ Reset_Handler:
 #endif
 
 #if (DFU_BOOTSTRAP_GPIO != _DISABLE)
-/* pulling high bootstrap pin */
+/* Set pull up/down/none for bootstrap pin */
     ldr     r1, =#DFU_BOOTSTRAP_GPIO
     ldr     r2, [r1, #GPIO_MODER]
     ldr     r3, =#(0x03 << (DFU_BOOTSTRAP_PIN * 2))
@@ -163,7 +163,12 @@ Reset_Handler:
     str     r2, [r1, #GPIO_MODER]
     ldr     r2, [r1, #GPIO_PUPDR]
     bics    r2, r3
-    ldr     r3, =#(0x01 << (DFU_BOOTSTRAP_PIN * 2))
+#if ( (!defined(DFU_BOOTSTRAP_PULL)) || ( defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL==_UP)) )
+    movs    r3, #_UP
+#else
+    movs    r3, #DFU_BOOTSTRAP_PULL
+#endif
+    lsls    r3, #(DFU_BOOTSTRAP_PIN * 2)
     orrs    r2, r3
     str     r2, [r1, #GPIO_PUPDR]
 /* checking bootstrap pin */

--- a/mcu/stm32f303.S
+++ b/mcu/stm32f303.S
@@ -199,7 +199,12 @@ Reset_Handler:
     movs    r2, #0x00
     strb    r2, [r0, #RCC_AHBRSTR + 0x02]
     strb    r2, [r0, #RCC_AHBENR + 0x02]
+#if ( (!defined(DFU_BOOTSTRAP_LEVEL)) || ( defined(DFU_BOOTSTRAP_LEVEL) && (DFU_BOOTSTRAP_LEVEL==_LOW)) )
     cbz     r4, .L_start_boot
+#else
+    cbnz    r4, .L_start_boot
+#endif
+
 /* jump to user section */
     ldr     r0, =#_APP_START
     ldr     r1, =#SCB

--- a/mcu/stm32f4xx.S
+++ b/mcu/stm32f4xx.S
@@ -154,7 +154,11 @@ Reset_Handler:
     str     r3, [r1, #GPIO_MODER]
     ldr     r3, [r1, #GPIO_PUPDR]
     bics    r3, r2
-    movs    r2, #0x01
+#if ( (!defined(DFU_BOOTSTRAP_PULL)) || ( defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL==_UP)) )
+    movs    r2, #_UP
+#else
+    movs    r2, #DFU_BOOTSTRAP_PULL
+#endif
     lsls    r2, #(DFU_BOOTSTRAP_PIN * 2)
     orrs    r3, r2
     str     r3, [r1, #GPIO_PUPDR]

--- a/mcu/stm32f4xx.S
+++ b/mcu/stm32f4xx.S
@@ -179,7 +179,11 @@ Reset_Handler:
     movs    r2, #0x00
     strb    r2, [r0, #RCC_AHB1RSTR]
     strb    r2, [r0, #RCC_AHB1ENR]
+#if ( (!defined(DFU_BOOTSTRAP_LEVEL)) || ( defined(DFU_BOOTSTRAP_LEVEL) && (DFU_BOOTSTRAP_LEVEL==_LOW)) )
     cbz     r4, .L_start_boot
+#else
+    cbnz    r4, .L_start_boot
+#endif
 #endif
 
 /* jump to user section */

--- a/mcu/stm32l0xx.S
+++ b/mcu/stm32l0xx.S
@@ -183,7 +183,11 @@ Reset_Handler:
     str     r2, [r0, #RCC_IOPRSTR]
     str     r2, [r0, #RCC_IOPENR]
     tst     r4, r4
+#if ( (!defined(DFU_BOOTSTRAP_LEVEL)) || ( defined(DFU_BOOTSTRAP_LEVEL) && (DFU_BOOTSTRAP_LEVEL==_LOW)) )
     beq     .L_start_boot
+#else
+    bne     .L_start_boot
+#endif
 #endif
 
 /* jump to user section */

--- a/mcu/stm32l0xx.S
+++ b/mcu/stm32l0xx.S
@@ -1,4 +1,4 @@
-#include "../config.h"
+#include "config.h"
 #define FLASH_R_BASE    0x40022000
 #define FLASH_ACR       0x00
 #define FLASH_PECR      0x04
@@ -157,7 +157,11 @@ Reset_Handler:
     str     r3, [r1, #GPIO_MODER]
     ldr     r3, [r1, #GPIO_PUPDR]
     bics    r3, r2
-    movs    r2, #0x01
+#if ( (!defined(DFU_BOOTSTRAP_PULL)) || ( defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL==_UP)) )
+    movs    r2, #_UP
+#else
+    movs    r2, #DFU_BOOTSTRAP_PULL
+#endif
     lsls    r2, #(DFU_BOOTSTRAP_PIN * 2)
     orrs    r3, r2
     str     r3, [r1, #GPIO_PUPDR]

--- a/mcu/stm32l1xx.S
+++ b/mcu/stm32l1xx.S
@@ -1,4 +1,4 @@
-#include "../config.h"
+#include "config.h"
 #define FLASH_R_BASE    0x40023C00
 #define FLASH_ACR       0x00
 #define FLASH_PECR      0x04
@@ -152,7 +152,11 @@ Reset_Handler:
     str     r3, [r1, #GPIO_MODER]
     ldr     r3, [r1, #GPIO_PUPDR]
     bics    r3, r2
-    movs    r2, #0x01
+#if ( (!defined(DFU_BOOTSTRAP_PULL)) || ( defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL==_UP)) )
+    movs    r2, #_UP
+#else
+    movs    r2, #DFU_BOOTSTRAP_PULL
+#endif
     lsls    r2, #(DFU_BOOTSTRAP_PIN * 2)
     orrs    r3, r2
     str     r3, [r1, #GPIO_PUPDR]

--- a/mcu/stm32l1xx.S
+++ b/mcu/stm32l1xx.S
@@ -177,7 +177,11 @@ Reset_Handler:
     movs    r2, #0x00
     strb    r2, [r0, #RCC_AHBRSTR]
     strb    r2, [r0, #RCC_AHBENR]
+#if ( (!defined(DFU_BOOTSTRAP_LEVEL)) || ( defined(DFU_BOOTSTRAP_LEVEL) && (DFU_BOOTSTRAP_LEVEL==_LOW)) )
     cbz     r4, .L_start_boot
+#else
+    cbnz    r4, .L_start_boot
+#endif
 #endif
 
 /* jump to user section */

--- a/mcu/stm32l4xx.S
+++ b/mcu/stm32l4xx.S
@@ -149,7 +149,11 @@ Reset_Handler:
     str     r3, [r1, #GPIO_MODER]
     ldr     r3, [r1, #GPIO_PUPDR]
     bics    r3, r2
-    movs    r2, #0x01
+#if ( (!defined(DFU_BOOTSTRAP_PULL)) || ( defined(DFU_BOOTSTRAP_PULL) && (DFU_BOOTSTRAP_PULL==_UP)) )
+    movs    r2, #_UP
+#else
+    movs    r2, #DFU_BOOTSTRAP_PULL
+#endif
     lsls    r2, #(DFU_BOOTSTRAP_PIN * 2)
     orrs    r3, r2
     str     r3, [r1, #GPIO_PUPDR]

--- a/mcu/stm32l4xx.S
+++ b/mcu/stm32l4xx.S
@@ -174,7 +174,11 @@ Reset_Handler:
     movs    r2, #0x00
     strb    r2, [r0, #RCC_AHB2RSTR]
     strb    r2, [r0, #RCC_AHB2ENR]
+#if ( (!defined(DFU_BOOTSTRAP_LEVEL)) || ( defined(DFU_BOOTSTRAP_LEVEL) && (DFU_BOOTSTRAP_LEVEL==_LOW)) )
     cbz     r4, .L_start_boot
+#else
+    cbnz    r4, .L_start_boot
+#endif
 #endif
 
 /* jump to user section */


### PR DESCRIPTION
Adds configuration options for the boot pin, 2 new defines:

DFU_BOOTSTRAP_PULL:

Can be set to _UP, _DOWN or _NONE to set the desired capability

DFU_BOOTSTRAP_LEVEL:

Can be set to _HIGH or _LOW, allows the logic level to be set according to hardware

(Some of the startup assembler files were including "../config.h" rather than "config.h", I have changed these to "config.h" as it allows sboot_stm32 to be used as a submodule without having to make file changes in tree, you just copy config.h to your own include directory and it uses that version)