### PR TITLE
fix ISR for the F0

### DIFF
--- a/mcu/stm32f0xx.S
+++ b/mcu/stm32f0xx.S
@@ -34,6 +34,7 @@
 #define GPIO_IDR        0x10
 
 #define SCB             0xE000ED00
+#define SCB_ICSR        0x04
 #define SCB_VTOR        0x08
 #define SCB_AIRCR       0x0C
 
@@ -101,7 +102,36 @@ __isr_vector:
     .long    0                              // Reserved
     .long    PendSV_Handler                 // PendSV Handler
     .long    SysTick_Handler                // SysTick Handler
-/* Peripheral interrupts are not used */
+/* Peripheral interrupts are not used
+ * but must be  */
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
+    .long    _default_handler
     .size    __isr_vector, . - __isr_vector
 
     .section .text
@@ -125,8 +155,8 @@ Reset_Handler:
     bne     .L_check_boot
 /* jump to user section */
     ldr     r0, = _APP_START
-    ldr     r1, = SCB
-    str     r0, [r1, SCB_VTOR] //set VTOR
+//    ldr     r1, = SCB
+//    str     r0, [r1, SCB_VTOR] //set VTOR
     ldr     r1, [r0, 0x00]
     msr     MSP, r1             //set MSP
     ldr     r3, [r0, 0x04]     //load reset vector
@@ -237,7 +267,7 @@ Reset_Handler:
 System_Reset:
     dsb
     ldr     r1, = SCB
-    ldr     r2, = 0x05FA0004;
+    ldr     r2, = 0x05FA0004
     str     r2, [r1, SCB_AIRCR]
     b .
 
@@ -274,15 +304,22 @@ System_Reset:
 
     .size Reset_Handler, . - Reset_Handler
 
-/*    Macro to define default handlers. Default handler
- *    will be weak symbol and just dead loops. They can be
- *    overwritten by other handlers */
+/*    Macro to define default handlers.
+ *    Since F0 doesn't support relocation of the ISR table
+ *    we need to resolve a new ISR vector via SCB->ICSR.
+ */
     .align 2
     .thumb_func
     .type _default_handler, %function
 
 _default_handler:
-    b .
+    ldr     r0, = SCB
+    ldr     r1, = _APP_START
+    ldr     r0, [r0, SCB_ICSR]
+    lsls    r0, #26
+    lsrs    r0, #24
+    ldr     r0, [r1, r0]
+    bx      r0
     .size _default_handler, . - _default_handler
 
     .pool

--- a/mcu/stm32f0xx.S
+++ b/mcu/stm32f0xx.S
@@ -102,8 +102,8 @@ __isr_vector:
     .long    0                              // Reserved
     .long    PendSV_Handler                 // PendSV Handler
     .long    SysTick_Handler                // SysTick Handler
-/* Peripheral interrupts are not used
- * but must be  */
+// Peripheral interrupts are not used but must be handled
+// to redirect to the application.
     .long    _default_handler
     .long    _default_handler
     .long    _default_handler
@@ -155,18 +155,17 @@ Reset_Handler:
     bne     .L_check_boot
 /* jump to user section */
     ldr     r0, = _APP_START
-//    ldr     r1, = SCB
-//    str     r0, [r1, SCB_VTOR] //set VTOR
+// no SCB->VTOR for F0
     ldr     r1, [r0, 0x00]
     msr     MSP, r1             //set MSP
-    ldr     r3, [r0, 0x04]     //load reset vector
+    ldr     r3, [r0, 0x04]      //load reset vector
     bx      r3                  //jump to user_app
 .L_check_boot:
 #if (DFU_DBLRESET_MS != _DISABLE)
 /* Storing DFU_BOOTKEY at DFU_BOOTKEY_ADDR and do a delay.
  * In case of RESET at this time bootloader will start from code above. */
     str     r2, [r1]
-/* STM32L0 startup clock is about 8MHz HSI
+/* STM32F0 startup clock is about 8MHz HSI
  * so, we need T(mS)*8000 ticks to make a required delay */
     ldr     r0, = (DFU_DBLRESET_MS * 8000 / 3)
 .L_rst_delay:
@@ -316,8 +315,8 @@ _default_handler:
     ldr     r0, = SCB
     ldr     r1, = _APP_START
     ldr     r0, [r0, SCB_ICSR]
-    lsls    r0, #26
-    lsrs    r0, #24
+    lsls    r0, 26
+    lsrs    r0, 24
     ldr     r0, [r1, r0]
     bx      r0
     .size _default_handler, . - _default_handler


### PR DESCRIPTION
Since F0 doesn't support the ISR table relocation via SCB->VTOR the bootloader must handle ISR, resolve an application ISR address and do a long jump to the ISR.