### PR TITLE
Fix RCC address for G4 bootstrap gpio setup

### DIFF
--- a/mcu/stm32g4xx.S
+++ b/mcu/stm32g4xx.S
@@ -170,7 +170,7 @@ Reset_Handler:
 /* checking bootstrap pin */
     ldr     r1, = DFU_BOOTSTRAP_GPIO
     movs    r2,  BOOTSTRAP_RCC
-    strb    r2, [r0, RCC_AHB2ENR]
+    strb    r2, [r5, RCC_AHB2ENR]
     movs    r2, 0x03
     lsls    r2, (DFU_BOOTSTRAP_PIN * 2)
     ldr     r3, [r1, GPIO_MODER]


### PR DESCRIPTION
I believe the G4 implementation is the only version that contained this mistake, but I could be wrong.

Looks like this was a copy/paste error or was missed in a refactor. I see that at one point r0 was used to store `RCC_BASE`, but now it's r5.