### PR TITLE
Add WCID mechanism

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -41,7 +41,8 @@ You can find configuration parameters in the following tables. Defaults marked *
 |DFU_BOOTSTRAP_PULL  | Bootstrap pin pullup control        | _DISABLE/**_AUTO**/_LOW/_HIGH  |                         |
 |DFU_DBLRESET_MS     | Doublereset activation time (ms)    | TIMEOUT/_DISABLE               | **300**                 |
 |DFU_APP_START       | Start address for user code         | ROM ADDRESS/**_AUTO**          | must be page aligned    |
-|DFU_APP_SIZE        | User application max size           | AMMOUNT/**_AUTO**              | up to the ROM end       |
+|DFU_APP_SIZE        | User application max size           | AMOUNT/**_AUTO**               | up to the ROM end       |
+|DFU_WCID            | Enables Microsoft OS Descriptors    | _ENABLE/**_DISABLE**           | Aut. Win. driver assign.|
 |DFU_CIPHER          | Type of ciper                       | See Table 3                    | **DFU_CIPHER_RC5**      |
 |DFU_CIPHER_MODE     | Cipher mode of operation            | See Table 4                    | **DFU_CIPHER_CBC**      |
 |DFU_AES_KEY_128     | 128-bit cipher key                  | Comma separated bytes          |                         |
@@ -93,3 +94,7 @@ You can find configuration parameters in the following tables. Defaults marked *
 |DFU_CIPHER_CFB  | Cipher Feedback (CFB)                    |
 |DFU_CIPHER_OFB  | Output Feedback (OFB)                    |
 |DFU_CIPHER_CTR  | Counter (CTR) (simply IV increment)      |
+
+
+### WCID
+DFU_WCID can be enabled to obtain a Microsoft-defined mechanism called WCID which is used by Windows to automatically assign a USB driver upon device connection. You probably want this as it enhances Windows user experience massively. See https://github.com/pbatard/libwdi/wiki/WCID-Devices

--- a/config.h
+++ b/config.h
@@ -173,6 +173,11 @@
 #ifndef DFU_APP_SIZE
 #define DFU_APP_SIZE        _AUTO
 #endif
+/* Microsoft WCID allows automatic driver (WinUSB) installation on device
+ * connection. Use _ENABLE to make your device likeable by Windows. */
+#ifndef DFU_WCID
+#define DFU_WCID _DISABLE
+#endif
 /* Cipher to use. set _DISABLE or choose from implemented ciphers */
 #ifndef DFU_CIPHER
 #define DFU_CIPHER          DFU_CIPHER_RC5

--- a/inc/descriptors.h
+++ b/inc/descriptors.h
@@ -21,6 +21,9 @@
 
 usbd_respond dfu_get_descriptor(usbd_ctlreq *req, void **address, uint16_t *len);
 
+#if (DFU_WCID != _DISABLE)
+usbd_respond dfu_get_vendor_descriptor(usbd_ctlreq *req, void**address, uint16_t *len);
+#endif
 
 #if defined (__cplusplus)
     }

--- a/inc/usb_msft.h
+++ b/inc/usb_msft.h
@@ -1,0 +1,41 @@
+#ifndef _USB_MSFT_H_
+#define _USB_MSFT_H_
+#if defined(__cplusplus)
+    extern "C" {
+#endif
+
+#include <stdint.h>
+
+/* Microsoft OS 1.0 descriptors */
+
+/* Extended Compat ID OS Feature Descriptor Specification */
+#define USB_MSFT_REQ_GET_COMPAT_ID_FEATURE_DESCRIPTOR 0x04
+
+/* Table 2. Function Section */
+struct usb_msft_compat_id_func_section {
+    uint8_t  bInterfaceNumber;
+    uint8_t  reserved0[1];
+    const char compatibleId[8];
+    const char subCompatibleId[8];
+    uint8_t  reserved1[6];
+} __attribute__((packed));
+
+#define USB_MSFT_COMPAT_ID_FUNCTION_SECTION_SIZE 24
+
+/* Table 1. Header Section */
+struct usb_msft_compat_id_desc {
+    uint32_t dwLength;
+    uint16_t bcdVersion;
+    uint16_t wIndex;
+    uint8_t  bNumSections;
+    uint8_t  reserved[7];
+    struct usb_msft_compat_id_func_section functions[];
+} __attribute__((packed));
+
+#define USB_MSFT_COMPAT_ID_HEADER_SIZE 16
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* _USB_MSFT_H_ */

--- a/src/bootloader.c
+++ b/src/bootloader.c
@@ -16,7 +16,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include "bootloader.h"
 #include "config.h"
 #include "stm32.h"
 #include "usb.h"
@@ -307,17 +306,9 @@ static void dfu_init (void) {
     usbd_connect(&dfu, 1);
 }
 
-void __attribute__ ((weak)) user_init() {
-}
-
-void __attribute__ ((weak)) user_poll() {
-}
-
 int main (void) {
     dfu_init();
-    user_init();
     while(1) {
         usbd_poll(&dfu);
-        user_poll();
     }
 }

--- a/src/bootloader.c
+++ b/src/bootloader.c
@@ -25,7 +25,7 @@
 #include "crypto.h"
 
 /* Checking for the EEPROM */
-#if defined(DATA_EEPROM_BASE) && defined(DATA_EEPROM_END)
+#if defined(DATA_EEPROM_BASE)
     #define _EE_START    DATA_EEPROM_BASE
     #define _EE_LENGTH   (DATA_EEPROM_END - DATA_EEPROM_BASE + 1)
 #elif defined(FLASH_EEPROM_BASE)


### PR DESCRIPTION
WCID is a Windows-only mechanism for automatic driver assignment for USB devices. 

The minimal solution consists of
- A special string descriptor at index 0xEE
- A "Compatible ID" Feature Descriptor that describes the driver type wanted ("WinUSB" is the driver name)

If Windows sees a device manifesting this, it assigns the relevant driver type to it.

The result is that the device can be accessed out of the box (by utilities such as dfu-util). [Zadig](https://zadig.akeo.ie/) (for manual installation of driver) is no longer needed to obtain working order.

My setup:
Flash usage with DFU_WCID: 4284
Flash usage without DFU_WCID: 4120

*Note 1. `WINUSB` is always assumed simply because it's the default Windows driver and I think it covers all cases; dfu-util supports this*
*Note 2. "Vendor Code " is a byte value that theoretically must match `bRequest` in the control transfer and is set by a byte in the EE string descriptor. Described [here](https://github.com/pbatard/libwdi/wiki/WCID-Devices#microsoft-compatible-id-feature-descriptor). This is kept at 0 and ignored since it has no significance.*

----

Further description at https://github.com/pbatard/libwdi/wiki/WCID-Devices

Implementation inspired from https://github.com/devanlai/dapboot/blob/01730698e2228605f36d5c77e61e67ea715690c1/src/winusb.c