### PR TITLE
Support for Timeout for inactivity. Support for SET_ADDRESS. Support for stm32g491. Support for ERASE_PAGE.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ FWTARGETS  += stm32l433xb stm32l433xc
 FWTARGETS  += stm32f070x6 stm32f070xb stm32f072x8
 FWTARGETS  += stm32g431x6 stm32g431x8 stm32g431xb
 FWTARGETS  += stm32g474xb stm32g474xc stm32g474xe
+FWTARGETS  += stm32g491xe stm32g491xc stm32g4a1xe stm32g4a1xc
 FWTARGETS  += stm32f446xc stm32f446xc_hs stm32f446xe stm32f446xe_hs
 FWTARGETS  += stm32f405xg stm32f405xg_hs
 
@@ -554,6 +555,30 @@ stm32g474xe :
 	                   FWSTARTUP='mcu/stm32g4xx.S' \
 	                   FWDEFS='STM32G4 STM32G474xx USBD_ASM_DRIVER' \
 	                   LDPARAMS='ROMLEN=512K RAMLEN=96K APPALIGN=0x1000'
+
+stm32g491xe :
+	${MAKE} bootloader FWCPU='-mcpu=cortex-m4' \
+	                   FWSTARTUP='mcu/stm32g4xx.S' \
+	                   FWDEFS='STM32G4 STM32G491xx USBD_ASM_DRIVER' \
+	                   LDPARAMS='ROMLEN=512K RAMLEN=96K APPALIGN=0x4000'
+
+stm32g491xc :
+	${MAKE} bootloader FWCPU='-mcpu=cortex-m4' \
+	                   FWSTARTUP='mcu/stm32g4xx.S' \
+	                   FWDEFS='STM32G4 STM32G491xx USBD_ASM_DRIVER' \
+	                   LDPARAMS='ROMLEN=256K RAMLEN=96K APPALIGN=0x4000'
+
+stm32g4a1xe :
+	${MAKE} bootloader FWCPU='-mcpu=cortex-m4' \
+	                   FWSTARTUP='mcu/stm32g4xx.S' \
+	                   FWDEFS='STM32G4 STM32G491xx USBD_ASM_DRIVER' \
+	                   LDPARAMS='ROMLEN=512K RAMLEN=96K APPALIGN=0x4000'
+
+stm32g4a1xc :
+	${MAKE} bootloader FWCPU='-mcpu=cortex-m4' \
+	                   FWSTARTUP='mcu/stm32g4xx.S' \
+	                   FWDEFS='STM32G4 STM32G491xx USBD_ASM_DRIVER' \
+	                   LDPARAMS='ROMLEN=256K RAMLEN=96K APPALIGN=0x4000'
 
 stm32f446xc :
 	$(MAKE) bootloader FWCPU='-mcpu=cortex-m4' \

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ The bootloader can be configured through the make parameters. See CONFIG.md for 
 | stm32g474xb   | STM32G471xB, STM32G473xB, STM32G474xB, STM32G483xB |                 |
 | stm32g474xc   | STM32G471xC, STM32G473xC, STM32G474xC, STM32G483xC |                 |
 | stm32g474xe   | STM32G471xE, STM32G473xE, STM32G474xE, STM32G483xE | tested G747RE   |
+| stm32g491xe   | STM32G491xE, STM32G4A1xE                           |
+| stm32g491xc   | STM32G491xC, STM32G4A1xC                           |
 | stm32f303xe   | STM32F303xE                                        | tested          |
 | stm32f373xc   | STM32F373xC                                        | tested          |
 

--- a/config.h
+++ b/config.h
@@ -115,7 +115,14 @@
 #define DFU_DSC_FLASH       _ENABLE
 #endif
 #ifndef DFU_STR_FLASH
+#if defined(STM32G491xx) //Cat4
+// NB: overstated for STM32G4x1xc which is only 256K
+#define DFU_STR_FLASH       "Internal flash/0x08000000/256*2KD"
+#elif defined(STM32F429xx)
+#define DFU_STR_FLASH       "Internal flash/0x08000000/4*16KD,1*64KD,6*128KD,4*16KD,1*64KD,6*128KD"
+#else
 #define DFU_STR_FLASH       "Internal flash"
+#endif
 #endif
 /* USB string for DFU EEPROM interface sreing descriptor */
 #ifndef DFU_DSC_EEPROM
@@ -128,13 +135,21 @@
 #define DFU_EP0_SIZE        8
 /* DFU properties */
 #ifndef DFU_POLL_TIMEOUT
+#if defined(STM32G491xx) //Cat4
+#define DFU_POLL_TIMEOUT    50
+#else
 #define DFU_POLL_TIMEOUT    20
+#endif
 #endif
 #ifndef DFU_DETACH_TIMEOUT
 #define DFU_DETACH_TIMEOUT  200
 #endif
 #ifndef DFU_BLOCKSZ
+#if defined(STM32G491xx) //Cat4
+#define DFU_BLOCKSZ         0x800
+#else
 #define DFU_BLOCKSZ         0x80
+#endif
 #endif
 /* 32 bit DFU bootkey value */
 #ifndef DFU_BOOTKEY

--- a/config.h
+++ b/config.h
@@ -117,9 +117,9 @@
 #ifndef DFU_STR_FLASH
 #if defined(STM32G491xx) //Cat4
 // NB: overstated for STM32G4x1xc which is only 256K
-#define DFU_STR_FLASH       "Internal flash/0x08000000/256*2KD"
+#define DFU_STR_FLASH       "Internal flash/0x08000000/256*2KE"
 #elif defined(STM32F429xx)
-#define DFU_STR_FLASH       "Internal flash/0x08000000/4*16KD,1*64KD,6*128KD,4*16KD,1*64KD,6*128KD"
+#define DFU_STR_FLASH       "Internal flash/0x08000000/4*16KE,1*64KE,6*128KE,4*16KE,1*64KE,6*128KE"
 #else
 #define DFU_STR_FLASH       "Internal flash"
 #endif

--- a/mcu/stm32g4xx.S
+++ b/mcu/stm32g4xx.S
@@ -326,6 +326,10 @@ program_flash:
 /* calculating PNB[6:0]: ADDR[17:11] -> CR[9:3] */
     lsrs    r4, 11
     bfi     r5, r4, 3, 7
+#elif defined(STM32G491xx) //Cat4
+/* calculating PNB[7:0]: ADDR[18:11] -> CR[10:3] */
+    lsrs    r4, 11
+    bfi     r5, r4, 3, 8
 #else // Cat3
 /* check dual bank */
     ldr     r5, [r3, FLASH_OPTR]


### PR DESCRIPTION
DFU_WATCHDOG is set to an ULL of counter running at the mcu set PLL clockrate to SYSCLK.

i.e. if clockrate for the specific mcu configuration is 36MHz, then define DFU_WATCHDOG to (120ULL * 36000000ULL) to get a 2 minute timeout.